### PR TITLE
feat: install_oh_my_zsh.sh 스크립트 macOS 호환성 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # **Oh My Zsh Installer with Plugins**
 
-This script automates the installation of **Oh My Zsh**, **Zsh autosuggestions**, and **Zsh syntax highlighting** on a new server. It also allows you to set Zsh as the default shell.
+This script automates the installation of **Oh My Zsh**, **Zsh autosuggestions**, and **Zsh syntax highlighting**. It supports both Debian-based Linux and macOS.
+
+## **Platform Support**
+- **Linux** (Debian, Ubuntu, etc.)
+- **macOS**
 
 ## **Features**
 - Installs **Oh My Zsh**.
@@ -9,52 +13,40 @@ This script automates the installation of **Oh My Zsh**, **Zsh autosuggestions**
 ---
 
 ## **Prerequisites**
-Ensure your server has the following installed:
-- `curl`
-- `git`
-- `zsh` (the script will install it if not already present)
+- **On Linux:** The script uses `apt-get` and will install `zsh`, `curl`, and `git`.
+- **On macOS:** You must have [Homebrew](https://brew.sh/) installed. The script will use it to install `zsh`, `curl`, and `git`.
 
 ---
 
-## **Installation**
-1. Clone this repository or download the script:
-   ```bash
-   git clone https://github.com/MNMaqsood/oh-my-zsh-installer.git
-   cd oh-my-zsh-installer
-   ```
+## **How to Run**
 
-2. Make the script executable:
-   ```bash
-   chmod +x install_oh_my_zsh.sh
-   ```
+1.  Clone this repository or download the `install_oh_my_zsh.sh` script:
+    ```bash
+    git clone https://github.com/MNMaqsood/oh-my-zsh-installer.git
+    cd oh-my-zsh-installer
+    ```
 
-3. Run the script with or without arguments:
+2.  Run the script using `bash`. This method does not require you to make the script executable with `chmod +x`.
 
-### **Usage**
-```bash
-./install_oh_my_zsh.sh [yes|no]
-```
+    ```bash
+    bash install_oh_my_zsh.sh [yes|no]
+    ```
 
-- **Arguments:**
-  - `yes`: Install Zsh and set it as the default shell.
-  - `no` (default): Install Zsh without changing the default shell.
+### **Arguments**
+-   **`yes`**: Install Oh My Zsh and set it as the default shell.
+-   **`no`** (or no argument): Install Oh My Zsh but do **not** change the default shell.
 
-**Examples:**
+### **Examples**
 
-- Install Oh My Zsh and make it the default shell:
-  ```bash
-  ./install_oh_my_zsh.sh yes
-  ```
+-   **Install and set as default:**
+    ```bash
+    bash install_oh_my_zsh.sh yes
+    ```
 
-- Install Oh My Zsh without changing the default shell:
-  ```bash
-  ./install_oh_my_zsh.sh no
-  ```
-
-- If no argument is passed, it defaults to `no`:
-  ```bash
-  ./install_oh_my_zsh.sh
-  ```
+-   **Install without setting as default:**
+    ```bash
+    bash install_oh_my_zsh.sh no
+    ```
 
 ## **License**
 This project is licensed under the [MIT License](LICENSE).

--- a/install_oh_my_zsh.sh
+++ b/install_oh_my_zsh.sh
@@ -14,14 +14,46 @@ MAKE_DEFAULT_SHELL="${1:-no}"
 # Display the selected option
 log "Make Zsh default shell: $MAKE_DEFAULT_SHELL"
 
-# Install Zsh
-log "Installing Zsh..."
-sudo apt update
-sudo apt install -y zsh curl git
+# --- OS-specific setup ---
+OS="$(uname -s)"
+case "$OS" in
+    Linux*)
+        log "Running on Linux"
+        log "Installing Zsh, curl, git..."
+        if ! command -v apt-get &> /dev/null; then
+            log "apt-get not found. This script supports Debian-based systems."
+            exit 1
+        fi
+        sudo apt-get update
+        sudo apt-get install -y zsh curl git
+        SED_INPLACE="sed -i"
+        ZSH_PATH=$(which zsh)
+        ;;
+    Darwin*)
+        log "Running on macOS"
+        if ! command -v brew &> /dev/null; then
+            log "Homebrew not found. Please install it from https://brew.sh/"
+            exit 1
+        fi
+        log "Installing Zsh, curl, git using Homebrew..."
+        brew install zsh curl git
+        SED_INPLACE="sed -i ''"
+        ZSH_PATH=$(brew --prefix)/bin/zsh
+        if ! grep -Fxq "$ZSH_PATH" /etc/shells; then
+            log "Adding Homebrew Zsh to /etc/shells..."
+            echo "$ZSH_PATH" | sudo tee -a /etc/shells
+        fi
+        ;;
+    *)
+        log "Unsupported OS: $OS"
+        exit 1
+        ;;
+esac
+# --- End OS-specific setup ---
 
 # Install Oh My Zsh if not already installed
 if [ -d "$HOME/.oh-my-zsh" ]; then
-    log "Oh My Zsh is already installed at $HOME/.oh-my-zsh. Skipping installation."
+    log "Oh My Zsh is already installed. Skipping installation."
 else
     log "Installing Oh My Zsh..."
     sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
@@ -30,38 +62,49 @@ fi
 # Set Zsh as the default shell if requested
 if [[ "$MAKE_DEFAULT_SHELL" == "yes" ]]; then
     log "Setting Zsh as the default shell..."
-    chsh -s $(which zsh)
+    chsh -s "$ZSH_PATH"
 else
     log "Zsh installation complete. Skipping setting it as the default shell."
 fi
 
-# Install Zsh autosuggestions
-if [ ! -d "$HOME/.oh-my-zsh/custom/plugins/zsh-autosuggestions" ]; then
+# Install Zsh plugins
+ZSH_CUSTOM=${ZSH_CUSTOM:-~/.oh-my-zsh/custom}
+PLUGINS_DIR="$ZSH_CUSTOM/plugins"
+AUTOSUGGESTIONS_DIR="$PLUGINS_DIR/zsh-autosuggestions"
+SYNTAX_HIGHLIGHTING_DIR="$PLUGINS_DIR/zsh-syntax-highlighting"
+
+if [ ! -d "$AUTOSUGGESTIONS_DIR" ]; then
     log "Installing Zsh autosuggestions..."
-    git clone https://github.com/zsh-users/zsh-autosuggestions ~/.oh-my-zsh/custom/plugins/zsh-autosuggestions
+    git clone https://github.com/zsh-users/zsh-autosuggestions "$AUTOSUGGESTIONS_DIR"
 else
     log "Zsh autosuggestions already installed. Skipping."
 fi
 
-# Install Zsh syntax highlighting
-if [ ! -d "$HOME/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting" ]; then
+if [ ! -d "$SYNTAX_HIGHLIGHTING_DIR" ]; then
     log "Installing Zsh syntax highlighting..."
-    git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ~/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting
+    git clone https://github.com/zsh-users/zsh-syntax-highlighting.git "$SYNTAX_HIGHLIGHTING_DIR"
 else
     log "Zsh syntax highlighting already installed. Skipping."
 fi
 
 # Update .zshrc to enable plugins
 log "Configuring Zsh plugins in .zshrc..."
-if ! grep -q "zsh-autosuggestions" ~/.zshrc; then
-    sed -i 's/plugins=(git)/plugins=(git zsh-autosuggestions zsh-syntax-highlighting)/' ~/.zshrc
-    log "Updated plugins in .zshrc."
+if ! grep -q "plugins=(git zsh-autosuggestions zsh-syntax-highlighting)" ~/.zshrc; then
+    if grep -q "plugins=(git)" ~/.zshrc; then
+        $SED_INPLACE 's/plugins=(git)/plugins=(git zsh-autosuggestions zsh-syntax-highlighting)/' ~/.zshrc
+        log "Updated plugins in .zshrc."
+    else
+        log "Could not find 'plugins=(git)' in .zshrc. Please add plugins manually."
+    fi
 else
     log "Plugins already configured in .zshrc."
 fi
 
-# Apply changes
-log "Applying changes..."
-zsh -c "source ~/.zshrc"
+log "Verifying .zshrc..."
+if zsh -c "source ~/.zshrc"; then
+    log ".zshrc verified successfully."
+else
+    log "There might be an issue with your .zshrc file."
+fi
 
-log "Oh My Zsh installation completed with autosuggestions and syntax highlighting enabled!"
+log "Installation complete! Please start a new Zsh session to see the changes."


### PR DESCRIPTION
이 커밋은 `install_oh_my_zsh.sh` 스크립트를 수정하여 Debian 기반 Linux와 macOS 모두에서 작동하도록 개선합니다.

주요 변경 사항:
- `uname -s`를 사용하여 운영 체제를 감지하는 로직을 추가했습니다.
- macOS에서는 Homebrew (`brew`)를, Linux에서는 `apt-get`을 사용하여 종속성(`zsh`, `curl`, `git`)을 설치하도록 분기 처리했습니다.
- Linux와 macOS 간의 `sed -i` 명령어 구문 비호환성 문제를 해결했습니다.
- `README.md`를 업데이트하여 macOS 지원을 명시하고, `chmod +x` 없이 `bash install_oh_my_zsh.sh` 명령으로 스크립트를 실행하는 방법을 안내합니다.